### PR TITLE
feat: Add macOS support and improve platform compatibility

### DIFF
--- a/experiments.py
+++ b/experiments.py
@@ -1,84 +1,132 @@
 import subprocess
+import sys
+import os
 from modules import *
 
-# Function to get the package manager - works on debian and arch
-# Then takes that package manager and runs the proper command to see manually installed packages
-# Only arch support exists as of now so serves more of a check more than anything
+# Function to get the package manager - now works on Debian, Arch, and macOS (with Homebrew)
 def get_manager():
-    with open("/etc/os-release") as f:
-        data = f.read()
-    if "arch" in data:
-        return "pacman"
-    elif "debian" in data:
-       return "apt"
-    else:
-        return ""
+    """
+    Identifies the system's primary package manager.
+    """
+    if sys.platform == "darwin":  # macOS
+        # Check for Homebrew on Apple Silicon or Intel paths
+        if os.path.exists("/opt/homebrew/bin/brew") or os.path.exists("/usr/local/bin/brew"):
+            return "brew"
+    elif sys.platform.startswith("linux"):  # Linux
+        try:
+            with open("/etc/os-release") as f:
+                data = f.read()
+            if "arch" in data:
+                return "pacman"
+            elif "debian" in data or "ubuntu" in data:
+                return "apt"
+        except FileNotFoundError:
+            # This case is for linux distros without /etc/os-release
+            return ""
+    return ""  # Return empty for unsupported OS or no manager found
 
-# Function to get an array of installed packages
-def pkglist(commands, installed_pkgs, prefixes, name_index1, name_index2):
+# Simplified function to get an array of installed packages from command history
+def pkglist(commands, installed_pkgs, prefixes, name_index):
+    """
+    Parses command history to find packages that were installed and are still present on the system.
+    """
     pkgs = []
     for cmd in commands:
         for prefix in prefixes:
             if cmd.startswith(prefix):
                 parts = cmd.split()
-                pkg_name = parts[name_index1] if parts[0] == prefix.split()[0] else parts[name_index2]
-                if pkg_name in installed_pkgs:
-                    pkgs.append(pkg_name)
+                if len(parts) > name_index:
+                    pkg_name = parts[name_index]
+                    if pkg_name in installed_pkgs:
+                        pkgs.append(pkg_name)
     return list(set(pkgs))
 
-# Function to get all packages that have been installed manually in the shell using pacman
-# Takes all attempted installation commands and checks them against packages currently on the system
-def pacman_pkgs(color):
+# Function to get all packages that have been installed manually via system package manager
+def system_pkgs(color):
+    """
+    Finds packages installed via the system's native package manager (apt, pacman, brew)
+    by cross-referencing command history with currently installed packages.
+    """
     try:
-        pkgs = []
         manager = get_manager()
+        if not manager:
+            return
+
+        # --- Get list of manually installed packages from the system ---
         if manager == "pacman":
             qe_pkgs_cmd = "pacman -Qe"
         elif manager == "apt":
             qe_pkgs_cmd = "apt-mark showmanual"
+        elif manager == "brew":
+            qe_pkgs_cmd = "brew leaves"
         else:
             return
 
-        qe_pkgs = subprocess.run(qe_pkgs_cmd, shell=True, capture_output=True, text=True)
-        if not qe_pkgs:
+        qe_pkgs_result = subprocess.run(qe_pkgs_cmd, shell=True, capture_output=True, text=True, check=False)
+        if qe_pkgs_result.returncode != 0:
             return
-        qe_pkgs = set(pkg.split()[0] for pkg in qe_pkgs.stdout.splitlines())
+
+        if manager in ["pacman", "apt"]:
+            installed_pkgs = set(pkg.split()[0] for pkg in qe_pkgs_result.stdout.splitlines())
+        else:  # brew
+            installed_pkgs = set(qe_pkgs_result.stdout.splitlines())
+
+        # --- Check history for installation commands ---
+        pkgs = []
         if manager == "pacman":
-            pkgs = pkglist(args_by_cmd["sudo"], qe_pkgs, ["pacman -S "], 2, 2)
+            if "sudo" in args_by_cmd:
+                pkgs = pkglist(args_by_cmd["sudo"], installed_pkgs, ["pacman -S "], 2)
         elif manager == "apt":
-            pkgs = pkglist(args_by_cmd["sudo"], qe_pkgs, ["apt install ", "apt-get install "], 2, 2)
+            if "sudo" in args_by_cmd:
+                pkgs = pkglist(args_by_cmd["sudo"], installed_pkgs, ["apt install ", "apt-get install "], 2)
+        elif manager == "brew":
+            if "brew" in args_by_cmd:
+                pkgs = pkglist(args_by_cmd["brew"], installed_pkgs, ["install "], 1)
+
         if pkgs:
-            max_len = max(len(pkg) for pkg in pkgs)
+            max_len = max(len(pkg) for pkg in pkgs) if pkgs else 0
             print(f"\n{getheadercolor()}Packages installed using {manager}:")
             for i in range(0, len(pkgs), 2):
                 pkg1 = pkgs[i]
                 pkg2 = pkgs[i + 1] if i + 1 < len(pkgs) else ""
                 print(f"{getcolor(color, False)}{pkg1}{' ' * (max_len - len(pkg1) + 2)}{getcolor(color, False)}{pkg2}")
-    except KeyError:
+
+    except (KeyError, FileNotFoundError):
+        # Gracefully fail if a command isn't in history or another file issue occurs.
         pass
 
 # Function to get all packages that have been installed manually in the shell
 # This one works for non-sudo aur helpers (paru or yay)
 def aur_pkgs(man, color):
+    """
+    Finds packages installed using an AUR helper (Arch Linux specific).
+    """
+    # This function is specific to Arch Linux AUR helpers, so we check the manager.
+    if get_manager() != "pacman":
+        return
     try:
         pkgs = []
         max_len = 0
-        qe_pkgs = subprocess.run(f"{man} -Qe", shell=True, capture_output=True, text=True)
-        qe_pkgs = qe_pkgs.stdout.splitlines()
-        for i in range(len(qe_pkgs)):
-            qe_pkgs[i] = qe_pkgs[i].split()[0]
-        for i in range(len(args_by_cmd[man])):
-            if args_by_cmd[man][i].startswith("-S "):
-                pkg = args_by_cmd[man][i].split()
-                if pkg[1] in qe_pkgs:
-                    if len(pkg[1]) > max_len: max_len = len(pkg[1])
-                    pkgs.append(pkg[1])
-        pkgs = list(set(pkgs))
-        print(f"\n{getheadercolor()}Packages installed using {man}:")
-        for i in range(0, len(pkgs), 2):
-            pkg1 = pkgs[i]
-            pkg2 = pkgs[i + 1] if i + 1 < len(pkgs) else ""
-            print(f"{getcolor(color, False)}{pkg1}{' ' * (max_len - len(pkg1) + 2)}{getcolor(color, False)}{pkg2}")
-    except KeyError:
-        pass
+        qe_pkgs_result = subprocess.run(f"{man} -Qe", shell=True, capture_output=True, text=True, check=False)
+        if qe_pkgs_result.returncode != 0:
+            return
+            
+        qe_pkgs = {pkg.split()[0] for pkg in qe_pkgs_result.stdout.splitlines()}
+        
+        if man in args_by_cmd:
+            for cmd in args_by_cmd[man]:
+                if cmd.startswith("-S "):
+                    pkg_name = cmd.split()[1]
+                    if pkg_name in qe_pkgs:
+                        if len(pkg_name) > max_len: max_len = len(pkg_name)
+                        pkgs.append(pkg_name)
 
+        pkgs = list(set(pkgs))
+        if pkgs:
+            print(f"\n{getheadercolor()}Packages installed using {man}:")
+            for i in range(0, len(pkgs), 2):
+                pkg1 = pkgs[i]
+                pkg2 = pkgs[i + 1] if i + 1 < len(pkgs) else ""
+                print(f"{getcolor(color, False)}{pkg1}{' ' * (max_len - len(pkg1) + 2)}{getcolor(color, False)}{pkg2}")
+    except (KeyError, FileNotFoundError):
+        pass

--- a/wrapped.py
+++ b/wrapped.py
@@ -1,5 +1,5 @@
 from modules import *
-from experiments import pacman_pkgs, aur_pkgs
+from experiments import system_pkgs, aur_pkgs
 
 setheadercolor("teal")
 clear()
@@ -16,6 +16,6 @@ hourly("green", "purple")
 byweekday("purple", "blue")
 hourchart("green", "purple")
 daychart("green", "yellow")
-pacman_pkgs("blue")
+system_pkgs("blue") # Changed from pacman_pkgs
 aur_pkgs("yay", "purple")
 reset()


### PR DESCRIPTION
### Description

This PR adds support for running the script on macOS while preserving the existing functionality for Arch and Debian-based Linux distributions.

The original script would fail on macOS for two main reasons:
1.  The shell detection did not handle the hyphenated output from `ps` for login shells.
2.  The package manager detection relied on `/etc/os-release`, which does not exist on macOS, causing a `FileNotFoundError`.

### Changes Made

-   **`parser.py`**: Fixed shell detection to correctly handle login shells (e.g., `-zsh`).
-   **`experiments.py`**:
    -   Implemented OS detection using `sys.platform`.
    -   Added support for the Homebrew (`brew`) package manager on macOS.
    -   Renamed `pacman_pkgs` to `system_pkgs` to better reflect its new capabilities.
    -   Prevented the `aur_pkgs` function from running on non-Arch systems.
-   **`wrapped.py`**: Updated the main script to call the renamed `system_pkgs` function.

These changes make the tool more robust and expand its utility to macOS users without breaking compatibility for existing Linux users.
